### PR TITLE
Eliminate the need to reload, and fix wrong IDs

### DIFF
--- a/src/URIModal.ts
+++ b/src/URIModal.ts
@@ -79,12 +79,10 @@ export default class URIModal extends Modal {
 
 		saveButton.onClickEvent(async () => {
 			if (this.editMode === false) { //creating a new command
-				this.plugin.settings.URICommands.push(this.uriCommand);
-				this.plugin.addURICommand(this.uriCommand);
 				//replace spaces with - and add unix millisec timestamp (to ensure uniqueness)
 				this.uriCommand.id = this.uriCommand.name.trim().replace(" ", "-").toLowerCase() + moment().valueOf();
-			} else { //editing an existing command
-				new Notice("You will need to restart Obsidian for the change to fully take effect.")
+				this.plugin.settings.URICommands.push(this.uriCommand);
+				this.plugin.addURICommand(this.uriCommand);
 			}
 
 			await this.plugin.saveSettings();	

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -62,10 +62,11 @@ export class URISettingTab extends PluginSettingTab {
                     button.setIcon("trash")
                           .setTooltip("Remove command")
                           .onClick(async () => {
+                            // Unregister the command from the palette
+                            (this.app as any).commands.removeCommand(`${this.plugin.manifest.id}:${command.id}`);
                             this.plugin.settings.URICommands.remove(command);
                             await this.plugin.saveSettings();
                             this.display();
-                            new Notice("You will need to restart Obsidian for the command to disappear.")
                         })
                 })
                 .addExtraButton(button => {


### PR DESCRIPTION
While trying out the fix for #3, I discovered that the initial assignment of the ID was happening *after* the call to `addURICommand()`, which means that new commands were always given an internal ID of `uri-commands:` (with no actual command ID following the ":").  I went ahead and made a pull request to fix this problem, and in the process also made it so that it isn't necessary to reload Obsidian or the plugin when commands are changed or deleted.  Hope you find it helpful, please let me know if you have any questions about what was done or how it works.